### PR TITLE
Memleak

### DIFF
--- a/include/bsmfilter.hpp
+++ b/include/bsmfilter.hpp
@@ -535,9 +535,7 @@ class BSMHandler {
         bool get_value_;                            ///< Indicates the next value should be saved.
         std::string json_;                          ///< The JSON string after redaction.
 
-        // JMC: Leak shouldn't be here -- only doubles and no statics.
         VelocityFilter vf_;                         ///< The velocity filter functor instance.
-        // JMC: Leak shouldn't be here -- only doubles and no statics.
         IdRedactor idr_;                            ///< The ID Redactor to use during parsing of BSMs.
 
         double box_extension_;                      ///< The number of meters to extend the boxes that surround edges and define the geofence.

--- a/include/bsmfilter.hpp
+++ b/include/bsmfilter.hpp
@@ -521,7 +521,11 @@ class BSMHandler {
         const double get_box_extension() const;
         
     private:
-        rapidjson::Document document_;              ///< JSON DOM
+
+        // TODO: I think the leak is here -- something in this document is not getting clearned up.
+        // TODO: Strategy - make new document every time we process!
+        // rapidjson::Document document_;              ///< JSON DOM
+
         uint32_t activated_;                        ///< A flag word indicating which features of the privacy protection are activiated.
 
         bool finalized_;                            ///< Indicates the JSON string after redaction has been created and retrieved.
@@ -531,7 +535,9 @@ class BSMHandler {
         bool get_value_;                            ///< Indicates the next value should be saved.
         std::string json_;                          ///< The JSON string after redaction.
 
+        // JMC: Leak shouldn't be here -- only doubles and no statics.
         VelocityFilter vf_;                         ///< The velocity filter functor instance.
+        // JMC: Leak shouldn't be here -- only doubles and no statics.
         IdRedactor idr_;                            ///< The ID Redactor to use during parsing of BSMs.
 
         double box_extension_;                      ///< The number of meters to extend the boxes that surround edges and define the geofence.

--- a/include/bsmfilter.hpp
+++ b/include/bsmfilter.hpp
@@ -522,8 +522,8 @@ class BSMHandler {
         
     private:
 
-        // TODO: I think the leak is here -- something in this document is not getting clearned up.
-        // TODO: Strategy - make new document every time we process!
+        // JMC: The leak seems to be caused by re-using the RapidJSON document instance.
+        // JMC: We will use a unique instance for each message.
         // rapidjson::Document document_;              ///< JSON DOM
 
         uint32_t activated_;                        ///< A flag word indicating which features of the privacy protection are activiated.

--- a/src/bsmfilter.cpp
+++ b/src/bsmfilter.cpp
@@ -285,7 +285,6 @@ BSMHandler::ResultStringMap BSMHandler::result_string_map{
         };
 
 BSMHandler::BSMHandler(Quad::Ptr quad_ptr, const ConfigMap& conf ):
-    // document_{},
     activated_{0},
     result_{ ResultStatus::SUCCESS },
     bsm_{},

--- a/src/ppm.cpp
+++ b/src/ppm.cpp
@@ -784,10 +784,13 @@ int PPM::operator()(void) {
         // consume-produce loop.
         while (bsms_available) {
 
+            // JMC: Leak option 3
             std::unique_ptr<RdKafka::Message> msg{ consumer->consume( consumer_timeout ) };
 
+            // JMC: Leak option 1
             if ( msg_consume(msg.get(), NULL, handler) ) {
 
+                // JMC: Leak option 2
                 status = producer->produce(filtered_topic.get(), partition, RdKafka::Producer::RK_MSG_COPY, (void *)handler.get_json().c_str(), handler.get_bsm_buffer_size(), NULL, NULL);
 
                 if (status != RdKafka::ERR_NO_ERROR) {

--- a/src/ppm.cpp
+++ b/src/ppm.cpp
@@ -768,6 +768,7 @@ int PPM::operator()(void) {
             continue;
         }
 
+        // JMC: There was leak in here caused by RapidJSON.  It has been fixed.  The notes are in that class's code.
         BSMHandler handler{qptr, pconf};
 
         std::vector<RdKafka::TopicPartition*> partitions;
@@ -784,13 +785,10 @@ int PPM::operator()(void) {
         // consume-produce loop.
         while (bsms_available) {
 
-            // JMC: Leak option 3
             std::unique_ptr<RdKafka::Message> msg{ consumer->consume( consumer_timeout ) };
 
-            // JMC: Leak option 1
             if ( msg_consume(msg.get(), NULL, handler) ) {
 
-                // JMC: Leak option 2
                 status = producer->produce(filtered_topic.get(), partition, RdKafka::Producer::RK_MSG_COPY, (void *)handler.get_json().c_str(), handler.get_bsm_buffer_size(), NULL, NULL);
 
                 if (status != RdKafka::ERR_NO_ERROR) {


### PR DESCRIPTION
Fix to the small memory leak. The problem was the RapidJSON document instance was created one time and re-used. It seems there is something within that code that is not being freed. The fix was to create a document each time a message is processed to ensure it gets completely destroyed. We tested this overnight and the leak appears to be gone.